### PR TITLE
Devcontainer setup for verilator and RISC-V Toolchain

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:24.10
+
+# Install system dependencies and Verilator build deps
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git help2man perl python3 make autoconf g++ flex bison ccache \
+        libgoogle-perftools-dev numactl perl-doc \
+        ca-certificates \
+        libboost-all-dev \
+        libfl-dev libfl2 zlib1g zlib1g-dev \
+        autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev \
+        gawk build-essential texinfo gperf libtool patchutils bc \
+        libexpat-dev python3-pip iverilog gtkwave x11-apps && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build RISC-V toolchain with multilib (RV32+RV64 support)
+RUN git clone https://github.com/riscv/riscv-gnu-toolchain.git && \
+    cd riscv-gnu-toolchain && \
+    ./configure --prefix=/opt/riscv --enable-multilib && \
+    make -j$(nproc)
+
+ENV PATH="/opt/riscv/bin:${PATH}"
+
+# Install Verilator from source
+RUN git clone https://github.com/verilator/verilator && \
+    cd verilator && \
+    git checkout stable && \
+    autoconf && \
+    ./configure --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install
+
+# Set up a working directory
+WORKDIR /workspace
+
+CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Digital Tools for Synapse",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "runArgs": [
+    "-e",
+    "DISPLAY=host.docker.internal:0",
+    "-e",
+    "XAUTHORITY=/tmp/.Xauthority",
+    "-v",
+    "${localEnv:HOME}/.Xauthority:/tmp/.Xauthority"
+  ],
+  "mounts": [
+    "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
+  ]
+  // "containerEnv": {
+  //   "DISPLAY": "host.docker.internal:0"
+  // }
+}

--- a/veridian.yml
+++ b/veridian.yml
@@ -1,0 +1,46 @@
+# list of directories with header files
+include_dirs:
+  - rtl
+  - tb
+# list of directories to recursively search for SystemVerilog/Verilog sources
+source_dirs:
+  - rtl
+  - tb
+# if true, recursively search the working directory for files to run diagnostics on
+# default: true
+# auto_search_workdir: true,
+# verible tool configuration
+# verible:
+#   # verible-verilog-syntax configuration
+#   syntax:
+#     # default: true if in path
+#     enabled: true,
+#     path: "verible-verilog-syntax"
+#     # default: none
+#     # args:
+#     #   - arg1
+#     #   - arg2
+#   # verible-verilog-format configuration
+#   format:
+#     # default: true if in path
+#     enabled: true,
+#     path: "verible-verilog-format"
+#     # default: none
+#     # args:
+#     #   - arg1
+#     #   - arg2
+verilator:
+  # verilator configuration
+  syntax:
+    # default: true if in path
+    enabled: true
+    path: "verilator"
+    # default: specified below
+    args:
+      - --lint-only
+      - -Wall
+      - -Irtl
+      - -Itb
+# set log level
+# default: Info
+log_level: Debug


### PR DESCRIPTION
Includes Dockerfile for building a development environment with Verilator, RISC-V toolchain, and other dependencies. Adds `devcontainer.json` for VS Code integration and `veridian.yml` for Verilog linting configuration.

This way, we all share the same tools.

Can be started via

```
 devcontainer up --workspace-folder .
 devcontainer exec --workspace-folder . /bin/bash
```