### PR TITLE
Fix ALU SLT/SLTU comparison bug and register file improvements

### DIFF
--- a/rtl/core_modules/alu.v
+++ b/rtl/core_modules/alu.v
@@ -19,8 +19,8 @@ module alu (
             INSTR_SLL:   ALUoutput = rs1 << rs2[4:0];  // Logical left shift
             INSTR_SRL:   ALUoutput = rs1 >> rs2[4:0];  // Logical right shift
             INSTR_SRA:   ALUoutput = $signed(rs1) >>> rs2[4:0];  // Arithmetic right shift
-            INSTR_SLT:   ALUoutput = {32{$signed(rs1) < $signed(rs2)}};  // Set less than (signed comparison)
-            INSTR_SLTU:  ALUoutput = {32{rs1 < rs2}};  // Set less than (unsigned comparison)
+            INSTR_SLT:   ALUoutput = {31'b0, $signed(rs1) < $signed(rs2)};  // Set less than (signed comparison)
+            INSTR_SLTU:  ALUoutput = {31'b0, rs1 < rs2};  // Set less than (unsigned comparison)
             INSTR_ADDI:  ALUoutput = $signed(rs1) + $signed(imm);  // Add immediate
             INSTR_XORI:  ALUoutput = rs1 ^ imm;  // Bitwise XOR with immediate
             INSTR_ORI:   ALUoutput = rs1 | imm;  // Bitwise OR with immediate
@@ -28,8 +28,8 @@ module alu (
             INSTR_SLLI:  ALUoutput = rs1 << imm[4:0];  // Logical left shift with immediate
             INSTR_SRLI:  ALUoutput = rs1 >> imm[4:0];  // Logical right shift with immediate
             INSTR_SRAI:  ALUoutput = $signed(rs1) >>> imm[4:0];  // Arithmetic right shift with immediate
-            INSTR_SLTI:  ALUoutput = {32{$signed(rs1) < $signed(imm)}};  // Set less than immediate (signed comparison)
-            INSTR_SLTIU: ALUoutput = {32{rs1 < imm}};  // Set less than immediate (unsigned comparison)
+            INSTR_SLTI:  ALUoutput = {31'b0, $signed(rs1) < $signed(imm)};  // Set less than immediate (signed comparison)
+            INSTR_SLTIU: ALUoutput = {31'b0, rs1 < imm};  // Set less than immediate (unsigned comparison)
             default:     ALUoutput = 0;  // Default case: output zero
         endcase
     end

--- a/rtl/core_modules/registerfile.v
+++ b/rtl/core_modules/registerfile.v
@@ -1,58 +1,33 @@
+`default_nettype none
 
 module registerfile (
-    input clk,
-    input [4:0] rs1,
-    input [4:0] rs2,
-    input rs1_valid,
-    input rs2_valid,
-    input [4:0] rd,
-    input wr_en,
-    input [31:0] rd_value,
+    input wire clk,
+    input wire rst,
+    input wire [4:0] rs1,
+    input wire [4:0] rs2,
+    input wire rs1_valid,
+    input wire rs2_valid,
+    input wire [4:0] rd,
+    input wire wr_en,
+    input wire [31:0] rd_value,
 
     output reg [31:0] rs1_value,
     output reg [31:0] rs2_value
 );
 
     reg [31:0] register_file[31:0];
+    integer i;
 
     initial begin
-        register_file[0]  = 0;
-        register_file[1]  = 0;
-        register_file[2]  = 0;
-        register_file[3]  = 0;
-        register_file[4]  = 0;
-        register_file[5]  = 0;
-        register_file[6]  = 0;
-        register_file[7]  = 0;
-        register_file[8]  = 0;
-        register_file[9]  = 0;
-        register_file[10] = 0;
-        register_file[11] = 0;
-        register_file[12] = 0;
-        register_file[13] = 0;
-        register_file[14] = 0;
-        register_file[15] = 0;
-        register_file[16] = 0;
-        register_file[17] = 0;
-        register_file[18] = 0;
-        register_file[19] = 0;
-        register_file[20] = 0;
-        register_file[21] = 0;
-        register_file[22] = 0;
-        register_file[23] = 0;
-        register_file[24] = 0;
-        register_file[25] = 0;
-        register_file[26] = 0;
-        register_file[27] = 0;
-        register_file[28] = 0;
-        register_file[29] = 0;
-        register_file[30] = 0;
-        register_file[31] = 0;
+        for (i = 0; i < 32; i = i + 1) begin
+            register_file[i] = 0;
+        end
     end
 
+    // Combinational read with write-through forwarding
     always @(*) begin
         if (rs1_valid) begin
-            if(rs1 == rd && wr_en) begin
+            if (rs1 == rd && wr_en && rd != 5'b0) begin
                 rs1_value = rd_value; // Forwarding if rd is being written
             end else begin
                 rs1_value = register_file[rs1];
@@ -60,8 +35,9 @@ module registerfile (
         end else begin
             rs1_value = 32'b0; // Default value if rs1 is not valid
         end
+
         if (rs2_valid) begin
-            if(rs2 == rd && wr_en) begin
+            if (rs2 == rd && wr_en && rd != 5'b0) begin
                 rs2_value = rd_value; // Forwarding if rd is being written
             end else begin
                 rs2_value = register_file[rs2];
@@ -71,10 +47,21 @@ module registerfile (
         end
     end
 
-    always @(posedge clk) begin
-        register_file[0] <= 0;
-        if (wr_en && rd[4:0] != 0) begin
-            register_file[rd[4:0]] <= rd_value;
+    // Synchronous write with reset
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            // Clear all registers on reset
+            for (i = 0; i < 32; i = i + 1) begin
+                register_file[i] <= 32'b0;
+            end
+        end else begin
+            // x0 is always zero (hardwired)
+            register_file[0] <= 32'b0;
+            // Write to register file
+            if (wr_en && rd != 5'b0) begin
+                register_file[rd] <= rd_value;
+            end
         end
     end
+
 endmodule

--- a/rtl/riscv_cpu.v
+++ b/rtl/riscv_cpu.v
@@ -103,6 +103,7 @@ module riscv_cpu (
 
     registerfile rf_inst0 (
         .clk(clk),
+        .rst(rst),
         .rs1(decoder_inst0_rs1_out),
         .rs2(decoder_inst0_rs2_out),
         .rs1_valid(decoder_inst0_rs1_valid_out),

--- a/sim/fibonacci.c
+++ b/sim/fibonacci.c
@@ -1,6 +1,4 @@
 //very simple fibonacci sequence generator
-#include <stdlib.h>
-#include <stdbool.h>
 #include <stdint.h>
 
 #if defined(__linux__) || defined(__APPLE__)

--- a/tests/unit_tests/test_alu.py
+++ b/tests/unit_tests/test_alu.py
@@ -93,15 +93,15 @@ async def test_shifts(dut):
 async def test_comparisons(dut):
     """Test comparisons operations"""
     # Set less than (signed)
-    await verify_alu_operation(dut, 10, 20, 0, 0x9, 0, 0xFFFFFFFF, "SLT true")
+    await verify_alu_operation(dut, 10, 20, 0, 0x9, 0, 0x00000001, "SLT true")
     await verify_alu_operation(dut, 20, 10, 0, 0x9, 0, 0, "SLT false")
-    await verify_alu_operation(dut, 0x80000000, 1, 0, 0x9, 0, 0xFFFFFFFF, "SLT negative < positive")
+    await verify_alu_operation(dut, 0x80000000, 1, 0, 0x9, 0, 0x00000001, "SLT negative < positive")
     await verify_alu_operation(dut, 0, 0x80000000, 0, 0x9, 0, 0, "SLT positive > negative")
     
     # Set less than (unsigned)
-    await verify_alu_operation(dut, 10, 20, 0, 0xA, 0, 0xFFFFFFFF, "SLTU true")
+    await verify_alu_operation(dut, 10, 20, 0, 0xA, 0, 0x00000001, "SLTU true")
     await verify_alu_operation(dut, 20, 10, 0, 0xA, 0, 0, "SLTU false")
-    await verify_alu_operation(dut, 0, 1, 0, 0xA, 0, 0xFFFFFFFF, "SLTU zero < one")
+    await verify_alu_operation(dut, 0, 1, 0, 0xA, 0, 0x00000001, "SLTU zero < one")
     await verify_alu_operation(dut, 0x80000000, 1, 0, 0xA, 0, 0, "SLTU MSB high > low (unsigned)")
 
 @cocotb.test()
@@ -134,12 +134,12 @@ async def test_immediate_operations(dut):
     await verify_alu_operation(dut, 0x80000000, 0, 31, 0x11, 0, 0xFFFFFFFF, "SRAI max shift")
 
     # Set less than immediate (signed)
-    await verify_alu_operation(dut, 10, 0, 20, 0x12, 0, 0xFFFFFFFF, "SLTI true")
+    await verify_alu_operation(dut, 10, 0, 20, 0x12, 0, 0x00000001, "SLTI true")
     await verify_alu_operation(dut, 20, 0, 10, 0x12, 0, 0, "SLTI false")
-    await verify_alu_operation(dut, 0x80000000, 0, 0, 0x12, 0, 0xFFFFFFFF, "SLTI negative < zero")
+    await verify_alu_operation(dut, 0x80000000, 0, 0, 0x12, 0, 0x00000001, "SLTI negative < zero")
     
     # Set less than immediate (unsigned)
-    await verify_alu_operation(dut, 10, 0, 20, 0x13, 0, 0xFFFFFFFF, "SLTIU true")
+    await verify_alu_operation(dut, 10, 0, 20, 0x13, 0, 0x00000001, "SLTIU true")
     await verify_alu_operation(dut, 20, 0, 10, 0x13, 0, 0, "SLTIU false")
     await verify_alu_operation(dut, 0x80000000, 0, 1, 0x13, 0, 0, "SLTIU MSB high > low (unsigned)")
 
@@ -182,9 +182,9 @@ async def test_random_inputs(dut):
         elif instr == 0x9:  # SLT
             rs1_signed = rs1 if rs1 < 0x80000000 else rs1 - 0x100000000
             rs2_signed = rs2 if rs2 < 0x80000000 else rs2 - 0x100000000
-            expected = 0xFFFFFFFF if rs1_signed < rs2_signed else 0
+            expected = 1 if rs1_signed < rs2_signed else 0
         elif instr == 0xA:  # SLTU
-            expected = 0xFFFFFFFF if rs1 < rs2 else 0
+            expected = 1 if rs1 < rs2 else 0
         elif instr == 0xB:  # ADDI
             expected = (rs1 + imm) & 0xFFFFFFFF
         elif instr == 0xC:  # XORI
@@ -203,9 +203,9 @@ async def test_random_inputs(dut):
         elif instr == 0x12:  # SLTI
             rs1_signed = rs1 if rs1 < 0x80000000 else rs1 - 0x100000000
             imm_signed = imm if imm < 0x80000000 else imm - 0x100000000
-            expected = 0xFFFFFFFF if rs1_signed < imm_signed else 0
+            expected = 1 if rs1_signed < imm_signed else 0
         elif instr == 0x13:  # SLTIU
-            expected = 0xFFFFFFFF if rs1 < imm else 0
+            expected = 1 if rs1 < imm else 0
             
         await verify_alu_operation(dut, rs1, rs2, imm, instr, pc_input, expected, f"Random test instr=0x{instr:x}")
 


### PR DESCRIPTION
- Fixed ALU comparison bug: SLT/SLTU/SLTI/SLTIU now return 1 or 0 instead of 0xFFFFFFFF
- Rewrote register file with async reset, x0 hardwiring, and write-through forwarding
- Added reset signal wiring to CPU
- Removed unused includes from fibonacci.c