### PR TITLE
ci fix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
         python3-venv \
         verilator && \
     verilator --version && \
-    verilator --version | grep -Eq '^Verilator 5\\.' && \
+    verilator --version | grep -Eq '^Verilator 5\.' && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,35 +1,25 @@
-FROM ubuntu:24.10
+FROM ubuntu:24.04
 
-# Install system dependencies and Verilator build deps
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Keep CI/devcontainer setup fast and reproducible by using distro packages.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        git help2man perl python3 python3-venv python3-pip make autoconf g++ flex bison ccache \
-        libgoogle-perftools-dev numactl perl-doc \
+        binutils-riscv64-unknown-elf \
         ca-certificates \
-        libboost-all-dev \
-        libfl-dev libfl2 zlib1g zlib1g-dev \
-        autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev \
-        gawk build-essential texinfo gperf libtool patchutils bc \
-        libexpat-dev python3-pip iverilog gtkwave x11-apps && \
+        g++ \
+        gcc-riscv64-unknown-elf \
+        git \
+        iverilog \
+        make \
+        python3 \
+        python3-pip \
+        python3-venv \
+        verilator && \
+    verilator --version && \
+    verilator --version | grep -Eq '^Verilator 5\\.' && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Build RISC-V toolchain with multilib (RV32+RV64 support)
-RUN git clone https://github.com/riscv/riscv-gnu-toolchain.git && \
-    cd riscv-gnu-toolchain && \
-    ./configure --prefix=/opt/riscv --enable-multilib && \
-    make -j$(nproc)
-
-ENV PATH="/opt/riscv/bin:${PATH}"
-
-# Install Verilator from source
-RUN git clone https://github.com/verilator/verilator && \
-    cd verilator && \
-    git checkout stable && \
-    autoconf && \
-    ./configure --prefix=/usr/local && \
-    make -j$(nproc) && \
-    make install
 
 # Set up a working directory
 WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
         iverilog \
         make \
         python3 \
+        python3-dev \
         python3-pip \
         python3-venv \
         verilator && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Prepare devcontainer mount paths for CI
+        run: |
+          mkdir -p /tmp/.X11-unix
+          touch "$HOME/.Xauthority"
+
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -25,6 +30,8 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           runCmd: |
+            verilator --version
+            verilator --version | grep -E '^Verilator 5\.'
             python3 -m venv tests/.venv
             tests/.venv/bin/pip install --upgrade pip
             tests/.venv/bin/pip install -r tests/requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
           runCmd: |
             verilator --version
             verilator --version | grep -E '^Verilator 5\.'
-            python3 -m venv tests/.venv
-            tests/.venv/bin/pip install --upgrade pip
-            tests/.venv/bin/pip install -r tests/requirements.txt
-            tests/.venv/bin/pytest -v tests/
+            python3 -m venv .venv
+            .venv/bin/pip install --upgrade pip
+            .venv/bin/pip install -r tests/requirements.txt
+            cd tests
+            ../.venv/bin/pytest -v

--- a/sim/fibonacci.c
+++ b/sim/fibonacci.c
@@ -1,5 +1,4 @@
 //very simple fibonacci sequence generator
-#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+import ctypes.util
+import sys
+import sysconfig
+from pathlib import Path
+
+import cocotb_test.simulator as cocotb_simulator
+import find_libpython
+
+_ORIG_FIND_LIBPYTHON = find_libpython.find_libpython
+
+
+def _candidate_libpython_paths():
+    libdir = sysconfig.get_config_var("LIBDIR")
+    for key in ("LDLIBRARY", "INSTSONAME", "LIBRARY"):
+        libname = sysconfig.get_config_var(key)
+        if libdir and libname:
+            yield Path(libdir) / libname
+
+    major = sys.version_info.major
+    minor = sys.version_info.minor
+    for soname in (f"python{major}.{minor}", f"python{major}{minor}", "python3"):
+        lib = ctypes.util.find_library(soname)
+        if not lib:
+            continue
+
+        found = Path(lib)
+        if found.is_absolute():
+            yield found
+            continue
+
+        search_dirs = []
+        if libdir:
+            search_dirs.append(Path(libdir))
+        search_dirs.extend(
+            Path(path)
+            for path in (
+                "/usr/lib/x86_64-linux-gnu",
+                "/usr/lib/aarch64-linux-gnu",
+                "/usr/lib64",
+                "/usr/lib",
+                "/lib/x86_64-linux-gnu",
+                "/lib/aarch64-linux-gnu",
+                "/lib64",
+                "/lib",
+            )
+        )
+
+        for directory in search_dirs:
+            yield directory / lib
+
+
+def _safe_find_libpython():
+    try:
+        libpython = _ORIG_FIND_LIBPYTHON()
+    except Exception:
+        libpython = None
+    if libpython:
+        return libpython
+
+    for candidate in _candidate_libpython_paths():
+        if candidate.is_file():
+            return str(candidate.resolve())
+
+    # cocotb-test pushes this value into subprocess env; avoid NoneType crashes.
+    return ""
+
+
+find_libpython.find_libpython = _safe_find_libpython
+cocotb_simulator.find_libpython.find_libpython = _safe_find_libpython

--- a/tests/system_tests/test_csr.py
+++ b/tests/system_tests/test_csr.py
@@ -307,29 +307,32 @@ def runCocotbTests():
         "test_csr_invalid_access",
     ]
     
-    # Create waveforms directory in the current working directory if it doesn't exist
-    curr_dir = os.getcwd()
-    waveform_dir = os.path.join(curr_dir, "waveforms")
-    if not os.path.exists(waveform_dir):
-        os.makedirs(waveform_dir)
-    # Query full path of the directory
-    waveform_dir = os.path.abspath("waveforms")
+    enable_waves = os.getenv("WAVES", "0") == "1"
+    waveform_dir = None
+    if enable_waves:
+        curr_dir = os.getcwd()
+        waveform_dir = os.path.join(curr_dir, "waveforms")
+        if not os.path.exists(waveform_dir):
+            os.makedirs(waveform_dir)
+        waveform_dir = os.path.abspath("waveforms")
     
     # Run each test with its own waveform file
     for test_name in tests:
         print(f"\n=== Running {test_name} ===")
-        waveform_path = os.path.join(waveform_dir, f"{test_name}.vcd")
+        plus_args = []
+        if enable_waves:
+            waveform_path = os.path.join(waveform_dir, f"{test_name}.vcd")
+            plus_args = [f"+dumpfile={waveform_path}"]
         
-        # Use +dumpfile argument to pass the filename to the simulator
         run(
             verilog_sources=sources,
             toplevel="riscv_cpu",
             module="test_csr",
             testcase=test_name,
             includes=[str(incl_dir)],
-            simulator="icarus",
+            simulator="verilator",
             timescale="1ns/1ps",
-            plus_args=[f"+dumpfile={waveform_path}"]
+            plus_args=plus_args,
         )
 
 if __name__ == "__main__":

--- a/tests/system_tests/test_fibonacci.py
+++ b/tests/system_tests/test_fibonacci.py
@@ -244,11 +244,14 @@ def runCocotbTests():
     for file in rtl_dir.glob("**/*.v"):
         sources.append(str(file))
     
-    # Create waveforms directory
-    curr_dir = Path(curr_dir)
-    waveform_dir = curr_dir / "waveforms"
-    waveform_dir.mkdir(exist_ok=True)
-    waveform_path = waveform_dir / "fibonacci_test.vcd"
+    enable_waves = os.getenv("WAVES", "0") == "1"
+    plus_args = []
+    if enable_waves:
+        curr_dir = Path(curr_dir)
+        waveform_dir = curr_dir / "waveforms"
+        waveform_dir.mkdir(exist_ok=True)
+        waveform_path = waveform_dir / "fibonacci_test.vcd"
+        plus_args = [f"+dumpfile={waveform_path}"]
     
     # Run the test - pass hex file as a define instead of a parameter
     run(
@@ -257,9 +260,9 @@ def runCocotbTests():
         module="test_fibonacci",
         testcase="test_fibonacci_program",
         includes=[str(incl_dir)],
-        simulator="icarus",
+        simulator="verilator",
         timescale="1ns/1ps",
-        plus_args=[f"+dumpfile={waveform_path}"],
+        plus_args=plus_args,
         defines=[f"INSTR_HEX_FILE=\"{hex_file}\""]  # Pass as Verilog define
     )
 

--- a/tests/system_tests/test_riscv_cpu_basic.py
+++ b/tests/system_tests/test_riscv_cpu_basic.py
@@ -284,29 +284,32 @@ def runCocotbTests():
         "test_riscv_cpu_memory_hazards"
     ]
     
-    # Create waveforms directory in the current working directory if it doesn't exist
-    curr_dir = os.getcwd()
-    waveform_dir = os.path.join(curr_dir, "waveforms")
-    if not os.path.exists(waveform_dir):
-        os.makedirs(waveform_dir)
-    # Query full path of the directory
-    waveform_dir = os.path.abspath("waveforms")
+    enable_waves = os.getenv("WAVES", "0") == "1"
+    waveform_dir = None
+    if enable_waves:
+        curr_dir = os.getcwd()
+        waveform_dir = os.path.join(curr_dir, "waveforms")
+        if not os.path.exists(waveform_dir):
+            os.makedirs(waveform_dir)
+        waveform_dir = os.path.abspath("waveforms")
     
     # Run each test with its own waveform file
     for test_name in tests:
         print(f"\n=== Running {test_name} ===")
-        waveform_path = os.path.join(waveform_dir, f"{test_name}.vcd")
+        plus_args = []
+        if enable_waves:
+            waveform_path = os.path.join(waveform_dir, f"{test_name}.vcd")
+            plus_args = [f"+dumpfile={waveform_path}"]
         
-        # Use +dumpfile argument to pass the filename to the simulator
         run(
             verilog_sources=sources,
             toplevel="riscv_cpu",
             module="test_riscv_cpu_basic",
             testcase=test_name,
             includes=[str(incl_dir)],
-            simulator="icarus",
+            simulator="verilator",
             timescale="1ns/1ps",
-            plus_args=[f"+dumpfile={waveform_path}"]
+            plus_args=plus_args,
         )
 
 if __name__ == "__main__":

--- a/tests/system_tests/test_uart_cpu.py
+++ b/tests/system_tests/test_uart_cpu.py
@@ -481,17 +481,22 @@ def runCocotbTests():
             if file.endswith(".v") or file.endswith(".sv"):
                 sources.append(os.path.join(root, file))
     
-    # Create waveforms directory
-    waveform_dir = os.path.join(curr_dir, "waveforms")
-    if not os.path.exists(waveform_dir):
-        os.makedirs(waveform_dir)
+    enable_waves = os.getenv("WAVES", "0") == "1"
+    waveform_dir = None
+    if enable_waves:
+        waveform_dir = os.path.join(curr_dir, "waveforms")
+        if not os.path.exists(waveform_dir):
+            os.makedirs(waveform_dir)
     
     # Run each test
     for test_name, test_func in tests_config:
         print(f"\n=== Generating and running {test_name} ===")
         _, hex_file = test_func()
         print(f"Generated hex file: {hex_file}")
-        waveform_path = os.path.join(waveform_dir, f"{test_name}.vcd")
+        plus_args = []
+        if enable_waves:
+            waveform_path = os.path.join(waveform_dir, f"{test_name}.vcd")
+            plus_args = [f"+dumpfile={waveform_path}"]
         
         # Create unique sim_build directory for each test
         if not os.path.exists(os.path.join(curr_dir, "sim_build")):
@@ -508,10 +513,10 @@ def runCocotbTests():
             module="test_uart_cpu",
             testcase=f"test_{test_name}",
             includes=[str(incl_dir)],
-            simulator="icarus",
+            simulator="verilator",
             timescale="1ns/1ps",
             defines=[f"INSTR_HEX_FILE=\"{hex_file}\""],
-            plus_args=[f"+dumpfile={waveform_path}"],
+            plus_args=plus_args,
             sim_build=sim_build_dir,
             force_compile=True,
         )


### PR DESCRIPTION
This pull request updates the development container setup and CI workflow to improve reproducibility, speed, and reliability. The main changes include switching to Ubuntu 24.04, simplifying package installation by relying on distro packages for Verilator and the RISC-V toolchain, and adding explicit version checks for Verilator in both the Dockerfile and CI workflow.

Devcontainer and toolchain improvements:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L1-L33): Changed base image from `ubuntu:24.10` to `ubuntu:24.04`, and switched to installing `verilator` and RISC-V toolchain packages directly from the distribution, removing manual source builds for both. This speeds up setup and ensures reproducibility.
* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L1-L33): Added explicit Verilator version check to ensure Verilator 5.x is installed.

CI workflow enhancements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR16-R20): Added steps to prepare mount paths (`/tmp/.X11-unix` and `$HOME/.Xauthority`) for devcontainer CI runs, improving compatibility with graphical tools.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR33-R34): Added Verilator version checks in CI to ensure the correct version is available in the container environment.