### PR TITLE
Dcache feature

### DIFF
--- a/rtl/cache_fsm.v
+++ b/rtl/cache_fsm.v
@@ -1,0 +1,361 @@
+//replaces the data memory completely, the load_type handling is done by the cache itself
+module cache_fsm #(
+    parameter MEM_SIZE        = 1048576,
+    parameter CACHE_SIZE      = 1024,
+    parameter SETS            = 256,
+    parameter ADDRESS_WIDTH   = 32,
+    parameter DATA_WIDTH      = 32,
+    parameter TAG_WIDTH       = 18,
+    parameter SET_WIDTH       = 8,
+    parameter OFFSET_WIDTH    = 4,
+    parameter WAY             = 4,
+    parameter BYTE_OFFSET     = $clog2(DATA_WIDTH/8),
+    parameter WORDS_PER_BLOCK = 1 << OFFSET_WIDTH,
+    parameter BYTES_PER_WORD  = 4
+) ( 
+    input  logic                                        clk, 
+    input  logic                                        write_en,
+    input  logic                                        read_en,
+    input  logic                                        reset,
+    input  logic [DATA_WIDTH - 1 : 0]                   data_in,
+    input  logic [ADDRESS_WIDTH - 1 : 0]                mem_add,
+    input  logic [2 : 0]                                load_type,
+    input  logic [3 : 0]                                write_bytes_enable,
+    output logic                                        stall,
+    output logic [DATA_WIDTH - 1 : 0]                   data_out
+    //output logic                                        data_ready_main_mem
+);
+
+localparam ADD             = ADDRESS_WIDTH;
+localparam TAG_IN_ADD      = SET_WIDTH + OFFSET_WIDTH + BYTE_OFFSET;
+localparam SET_IN_ADD      = OFFSET_WIDTH + BYTE_OFFSET;
+localparam BYTE_OFFSET_ADD = BYTE_OFFSET;
+
+wire [TAG_WIDTH - 1 : 0]    tag        = mem_add[ADD - 1 : TAG_IN_ADD];        //tag separation
+wire [SET_WIDTH - 1 : 0]    set        = mem_add[TAG_IN_ADD - 1 : SET_IN_ADD]; //set separation
+wire [OFFSET_WIDTH - 1 : 0] offset     = mem_add[SET_IN_ADD - 1 : BYTE_OFFSET_ADD];//offset separation  
+wire [BYTE_OFFSET - 1 : 0] byte_offset = mem_add[BYTE_OFFSET_ADD - 1 : 0]; //byte offset separation
+
+// Internal memory(replaced data memory and now supports block extraction for the cache) its byte addressable like the data mem
+reg [7 : 0] MAIN_MEMORY [0:MEM_SIZE-1][0:WORDS_PER_BLOCK-1][0 : BYTES_PER_WORD - 1];
+
+//cache memory which is byte addressable too. sepearte tags for each way
+reg [7 : 0] CACHE_MEMORY        [0 : SETS - 1][0 : WAY - 1][0 : WORDS_PER_BLOCK - 1][0 : BYTES_PER_WORD - 1];
+reg [TAG_WIDTH - 1 : 0]  TAG_IN_CACHE_MEMORY [0 : SETS - 1][0 : WAY - 1];
+reg                      VALID               [0 : SETS - 1][0 : WAY - 1];
+reg                      DIRTY               [0 : SETS - 1][0 : WAY - 1];
+reg [1 : 0]              LRU_COUNTER         [0 : SETS - 1][0 : WAY - 1];
+
+
+reg [SET_WIDTH-1:0]    latched_set;
+reg [TAG_WIDTH-1:0]    latched_tag;
+reg [OFFSET_WIDTH-1:0] latched_offset;
+reg [BYTE_OFFSET-1:0]  latched_byte_offset;
+reg [1:0]              latched_victim;
+reg [TAG_WIDTH-1:0]    victim_tag;
+reg [DATA_WIDTH - 1 : 0] latched_data_in;
+
+// For write-allocate
+reg                    pending_write;
+reg [DATA_WIDTH-1:0]   pending_write_data;
+reg [OFFSET_WIDTH-1:0] pending_write_offset;
+reg [BYTE_OFFSET-1:0]  pending_write_byte_offset;
+
+logic[WAY - 1 : 0] HIT;
+logic[WAY - 1 : 0] valid;
+logic[WAY - 1 : 0] dirty;
+logic[WAY - 1 : 0] latched_hit;
+logic[WAY - 1 : 0] latched_valid;
+logic[WAY - 1 : 0] latched_dirty;
+
+typedef enum logic [2 : 0] {
+    IDLE,
+    READ,
+    WRITE,
+    READ_MISS,
+    GET_VICTIM,
+    WRITE_BACK,
+    READ_FROM_MAIN_MEM
+} state_type;
+
+state_type state_curr, state_next;
+
+always_comb begin
+    for (integer i = 0; i < WAY; i++) begin
+        HIT[i] = (VALID[set][i] && TAG_IN_CACHE_MEMORY[set][i] == tag);
+    end
+
+    for (integer i = 0; i < WAY; i++) begin
+        valid[i] = (VALID[set][i]);
+        dirty[i] = (DIRTY[set][i]);
+    end
+
+    for (integer i = 0; i < WAY; i++) begin
+        latched_hit[i]   = (VALID[latched_set][i] && TAG_IN_CACHE_MEMORY[latched_set][i] == latched_tag);
+        latched_valid[i] = VALID[latched_set][i];
+        latched_dirty[i] = DIRTY[latched_set][i];
+    end
+end
+
+
+function automatic [1 : 0] get_replacement;
+input [SET_WIDTH - 1 : 0] set_index;
+    begin
+    logic[1 : 0] max;
+    integer victim;
+        max    = 0;
+        victim = 0;
+
+        for (integer i = 0; i < WAY; i++) begin
+            if (LRU_COUNTER[set_index][i] > max) begin
+                max    = LRU_COUNTER[set_index][i];
+                victim = i;
+            end
+        end
+        return victim[1 : 0];
+    end
+endfunction
+
+function automatic [1  : 0] free_way;
+input[SET_WIDTH - 1 : 0] set_index;
+    begin
+        for (integer i = 0; i < WAY; i++) begin
+            if(VALID[set_index][i] == 1'b0) begin
+                return i[1 : 0];
+            end
+        end
+    end
+endfunction
+
+logic        write_hit;
+logic[1 : 0] write_hit_way;
+
+logic [ADDRESS_WIDTH-1:0] victim_addr;
+logic [ADDRESS_WIDTH-OFFSET_WIDTH-BYTE_OFFSET-1:0] victim_block_addr;
+logic [ADDRESS_WIDTH-OFFSET_WIDTH-BYTE_OFFSET-1:0] block_addr;
+
+always @(posedge clk) begin
+    if(reset) begin
+        state_curr           <= IDLE;
+        data_out             <= 'b0;
+        //data_ready_main_mem  <= 1'b0;
+        latched_set          <= 0;
+        latched_tag          <= 0;
+        latched_offset       <= 0;
+        latched_byte_offset  <= 0;
+        latched_victim       <= 0;
+        victim_tag           <= 0;
+        pending_write        <= 0;
+        pending_write_data   <= 0;
+        pending_write_offset <= 0;
+
+        for (integer i = 0; i < SETS; i++) begin
+            for (integer j = 0; j < WAY; j++) begin
+                LRU_COUNTER[i][j]         <= j[1 : 0];
+                TAG_IN_CACHE_MEMORY[i][j] <= 'b0;
+                VALID[i][j]               <= 'b0;
+                DIRTY[i][j]               <= 'b0;              
+            end
+        end
+
+        for (integer i = 0; i < SETS; i++) begin
+            for (integer j = 0; j < WAY; j++) begin
+                for (integer k = 0; k < WORDS_PER_BLOCK; k++) begin
+                    for(integer l = 0; l < BYTES_PER_WORD; l++) begin
+                       CACHE_MEMORY[i][j][k][l] <= 'b0; 
+                    end
+                end
+            end
+        end
+    end 
+    else begin
+
+    case (state_curr)
+        IDLE: begin
+            latched_set     <= set;
+            latched_tag     <= tag;
+            latched_offset  <= offset;
+            latched_byte_offset <= byte_offset;
+            latched_data_in <= data_in;
+            pending_write   <= 0;
+            stall           <= 0;
+
+            if(read_en) begin
+                state_curr <= READ;
+                stall      <= 1;
+            end else if(write_en) begin
+                state_curr <= WRITE;
+                stall      <= 1;
+            end
+        end
+
+        READ: begin
+            if (|latched_hit) begin
+                stall      <= 0;
+                state_curr <= IDLE;
+                for (integer i = 0; i < WAY; i++) begin
+                    if(latched_hit[i]) begin
+                        data_out                  <= read_en ? (
+                            (load_type == 3'b000) ? {{24{CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset][7]}}, CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset]} :
+                            (load_type == 3'b100) ? {24'h0, CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset]} :
+                            (load_type == 3'b001) ? {{16{CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset + 1][7]}}, CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset + 1],  CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset]}:
+                            (load_type == 3'b101) ? {16'h0, CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset + 1],  CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset]} :
+                            (load_type == 3'b010) ? {CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset + 3],  CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset + 2],  CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset + 1],  CACHE_MEMORY[latched_set][i][latched_offset][latched_byte_offset]} :
+                            32'h0
+                        ) : 32'h0;
+                        LRU_COUNTER[latched_set][i]       <= 0;
+                        for (integer j = 0; j < WAY; j++) begin
+                            if(j != i && VALID[latched_set][j]) begin
+                                LRU_COUNTER[latched_set][j] <= LRU_COUNTER[latched_set][j] + 1;
+                            end
+                        end
+                    end  
+                end
+            end                             
+            else begin
+                state_curr <= READ_MISS;
+            end
+        end
+
+        WRITE: begin
+            write_hit = 0;
+            for (integer i = 0; i < WAY; i++) begin
+                if(latched_hit[i] == 1) begin
+                    write_hit = 1;
+                end
+            end
+
+            if (write_hit) begin
+                write_hit_way = 0;
+                for (integer i = 0; i < WAY; i++) begin
+                    if(latched_hit[i] == 1) begin
+                        write_hit_way = i[1 : 0];
+                    end
+                end
+                if (write_bytes_enable[0]) begin
+                    CACHE_MEMORY[latched_set][write_hit_way][latched_offset][latched_byte_offset]     <= latched_data_in[7 : 0];
+                end
+                // For halfword writes: write 2 consecutive bytes
+                if (write_bytes_enable[1]) begin
+                    CACHE_MEMORY[latched_set][write_hit_way][latched_offset][latched_byte_offset + 1] <= latched_data_in[15 : 8];
+                end
+                // For word writes: write 4 consecutive bytes
+                if (write_bytes_enable[2]) begin
+                    CACHE_MEMORY[latched_set][write_hit_way][latched_offset][latched_byte_offset + 2] <= latched_data_in[23 : 16];
+                end
+                if (write_bytes_enable[3]) begin
+                    CACHE_MEMORY[latched_set][write_hit_way][latched_offset][latched_byte_offset + 3] <= latched_data_in[31 : 24];
+                end 
+                DIRTY[latched_set][write_hit_way]                        <= 1'b1;
+                TAG_IN_CACHE_MEMORY[latched_set][write_hit_way]          <= latched_tag;
+                VALID[latched_set][write_hit_way]                        <= 1'b1;
+                LRU_COUNTER[latched_set][write_hit_way]                  <= 0;
+                for (integer j = 0; j < WAY; j++) begin
+                    if (j[1 : 0] != write_hit_way && VALID[latched_set][j]) begin
+                        LRU_COUNTER[latched_set][j] <= LRU_COUNTER[latched_set][j] + 1;
+                    end
+                end
+                state_curr <= IDLE;   
+            end
+
+            else if(|latched_hit == 0) begin //write miss
+                pending_write             <= 1;
+                pending_write_data        <= latched_data_in;
+                pending_write_offset      <= latched_offset;
+                pending_write_byte_offset <= latched_byte_offset;
+                if (&latched_valid == 1) begin //all ways valid 
+                    state_curr <= READ_MISS;
+                end
+                else begin
+                    state_curr <= READ_MISS;
+                end
+            end 
+        end
+
+        READ_MISS: begin
+            if((&latched_valid == 1)) begin //if all ways valid, get victim
+                state_curr      <= GET_VICTIM;
+                latched_victim  <= get_replacement(latched_set);
+                victim_tag      <= TAG_IN_CACHE_MEMORY[latched_set][get_replacement(latched_set)];     
+            end else begin //atleast one way is free, no need to write-back
+                state_curr     <= READ_FROM_MAIN_MEM;
+                latched_victim <= free_way(latched_set); 
+                victim_tag     <= TAG_IN_CACHE_MEMORY[latched_set][free_way(latched_set)];
+            end
+        end
+
+        GET_VICTIM: begin
+            if(VALID[latched_set][latched_victim]) begin  
+                state_curr <= WRITE_BACK;
+            end else begin
+                state_curr <= READ_FROM_MAIN_MEM;  // Clean victim skip write-back
+            end  
+        end
+
+        WRITE_BACK: begin
+            state_curr <= READ_FROM_MAIN_MEM;
+                
+            for (integer i = 0; i < WORDS_PER_BLOCK; i++) begin
+                for(integer j = 0; j < BYTES_PER_WORD; j++) begin
+                    MAIN_MEMORY[victim_addr[19 : 0]][i][j] <= CACHE_MEMORY[latched_set][latched_victim][i][j];
+                end
+            end
+            //data_ready_main_mem <= 1'b1;
+            VALID[latched_set][latched_victim]  <= 1'b0;
+            DIRTY[latched_set][latched_victim]  <= 1'b0;
+        end
+
+        READ_FROM_MAIN_MEM: begin
+
+            for (integer i = 0; i < WORDS_PER_BLOCK; i++) begin
+                for(integer j = 0; j < BYTES_PER_WORD; j++) begin
+                    CACHE_MEMORY[latched_set][latched_victim][i][j] <= MAIN_MEMORY[block_addr[19 : 0]][i][j];
+                end
+            end
+            //data_ready_main_mem                      <= 1'b0;
+
+            if(pending_write) begin
+                if (write_bytes_enable[0]) begin
+                    CACHE_MEMORY[latched_set][latched_victim][pending_write_offset][pending_write_byte_offset] <= pending_write_data[7 : 0];
+                end
+                // For halfword writes: write 2 consecutive bytes
+                if (write_bytes_enable[1]) begin
+                    CACHE_MEMORY[latched_set][latched_victim][pending_write_offset][pending_write_byte_offset + 1] <= pending_write_data[15 : 8];
+                end
+                // For word writes: write 4 consecutive bytes
+                if (write_bytes_enable[2]) begin
+                    CACHE_MEMORY[latched_set][latched_victim][pending_write_offset][pending_write_byte_offset + 2] <= pending_write_data[23 : 16];
+                end
+                if (write_bytes_enable[3]) begin
+                    CACHE_MEMORY[latched_set][latched_victim][pending_write_offset][pending_write_byte_offset + 3] <= pending_write_data[31 : 24];
+                end
+                DIRTY[latched_set][latched_victim]                              <= 1'b1;
+            end 
+            else begin
+                DIRTY[latched_set][latched_victim]                              <= 1'b0;
+            end
+
+            TAG_IN_CACHE_MEMORY[latched_set][latched_victim] <= latched_tag;
+            VALID[latched_set][latched_victim]               <= 1'b1;
+            LRU_COUNTER[latched_set][latched_victim] <= 0;
+            for (integer j = 0; j < WAY; j++) begin
+                if(j[1 : 0] != latched_victim && VALID[latched_set][j]) begin
+                    LRU_COUNTER[latched_set][j] <= LRU_COUNTER[latched_set][j] + 1;
+                end
+            end
+            if(pending_write) begin
+                state_curr <= IDLE;
+                stall      <= 0;
+            end else begin
+                state_curr <= READ;
+            end
+        end
+        default: state_curr <= IDLE;
+    endcase
+    end 
+end
+
+assign victim_addr = {{6{1'b0}},victim_tag, latched_set};
+assign block_addr = {latched_tag, latched_set};
+
+endmodule

--- a/rtl/data_mem.v
+++ b/rtl/data_mem.v
@@ -1,10 +1,6 @@
 `default_nettype none
 `include "memory_map.vh"
-<<<<<<< HEAD
-
-=======
 //This module is obsolete now, the main memory is included in the cache itself
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
 // data_mem.v - byte-addressable data memory for RISC-V CPU
 
 module data_mem #(parameter DATA_WIDTH = 32, ADDR_WIDTH = 32, MEM_SIZE = 1048576) ( // 1MB = 1024*1024 bytes

--- a/rtl/data_mem.v
+++ b/rtl/data_mem.v
@@ -1,6 +1,10 @@
 `default_nettype none
 `include "memory_map.vh"
+<<<<<<< HEAD
 
+=======
+//This module is obsolete now, the main memory is included in the cache itself
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
 // data_mem.v - byte-addressable data memory for RISC-V CPU
 
 module data_mem #(parameter DATA_WIDTH = 32, ADDR_WIDTH = 32, MEM_SIZE = 1048576) ( // 1MB = 1024*1024 bytes

--- a/rtl/riscv_cpu.v
+++ b/rtl/riscv_cpu.v
@@ -8,10 +8,7 @@ module riscv_cpu (
     output wire [31:0] module_wr_data_out,
     output wire module_mem_wr_en,
     output wire module_mem_rd_en,
-<<<<<<< HEAD
-=======
     input wire  stall,
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     output wire [31:0] module_read_addr,
     output wire [31:0] module_write_addr,
     output wire [3:0] module_write_byte_enable,  // Write byte enables
@@ -28,10 +25,7 @@ module riscv_cpu (
     wire pc_inst0_j_signal;
     wire [31:0] pc_inst0_jump;
     wire stall_pipeline; // For load-use hazards
-<<<<<<< HEAD
-=======
 
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     // Branch handling: use EX stage jump signal/address
     assign pc_inst0_j_signal = ex_inst0_jump_signal_out;
     assign pc_inst0_jump = ex_inst0_jump_addr_out;
@@ -40,11 +34,7 @@ module riscv_cpu (
         .rst(rst),
         .j_signal(pc_inst0_j_signal),
         .jump(pc_inst0_jump),
-<<<<<<< HEAD
-        .stall(stall_pipeline), // Stall on load-use hazard
-=======
         .stall(stall_pipeline || stall), // Stall on load-use hazard
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
         .out(pc_inst0_out)
     );
 
@@ -63,11 +53,7 @@ module riscv_cpu (
         .rst(rst),
         .pc_in(pc_inst0_out),
         .instruction_in(branch_flush ? 32'h13 : module_instr_in),
-<<<<<<< HEAD
-        .stall(stall_pipeline), // Stall on load-use hazard
-=======
         .stall(stall_pipeline || stall), // Stall on load-use hazard or cache miss
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
         .pc_out(if_id_pc_out),
         .instruction_out(if_id_instr_out)
     );
@@ -167,11 +153,7 @@ module riscv_cpu (
         .pc_in(if_id_pc_out),
         .rs1_value_in(rf_inst0_rs1_value_out),
         .rs2_value_in(rf_inst0_rs2_value_out),
-<<<<<<< HEAD
-        .stall(pipeline_flush || stall_pipeline), // Use combined flush
-=======
         .stall(pipeline_flush || stall_pipeline || stall), // Use combined flush or stall on cache miss
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
         .rs1_valid_out(id_ex_inst0_rs1_valid_out),
         .rs2_valid_out(id_ex_inst0_rs2_valid_out),
         .rd_valid_out(id_ex_inst0_rd_valid_out),

--- a/rtl/riscv_cpu.v
+++ b/rtl/riscv_cpu.v
@@ -8,6 +8,10 @@ module riscv_cpu (
     output wire [31:0] module_wr_data_out,
     output wire module_mem_wr_en,
     output wire module_mem_rd_en,
+<<<<<<< HEAD
+=======
+    input wire  stall,
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     output wire [31:0] module_read_addr,
     output wire [31:0] module_write_addr,
     output wire [3:0] module_write_byte_enable,  // Write byte enables
@@ -24,6 +28,10 @@ module riscv_cpu (
     wire pc_inst0_j_signal;
     wire [31:0] pc_inst0_jump;
     wire stall_pipeline; // For load-use hazards
+<<<<<<< HEAD
+=======
+
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     // Branch handling: use EX stage jump signal/address
     assign pc_inst0_j_signal = ex_inst0_jump_signal_out;
     assign pc_inst0_jump = ex_inst0_jump_addr_out;
@@ -32,7 +40,11 @@ module riscv_cpu (
         .rst(rst),
         .j_signal(pc_inst0_j_signal),
         .jump(pc_inst0_jump),
+<<<<<<< HEAD
         .stall(stall_pipeline), // Stall on load-use hazard
+=======
+        .stall(stall_pipeline || stall), // Stall on load-use hazard
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
         .out(pc_inst0_out)
     );
 
@@ -51,7 +63,11 @@ module riscv_cpu (
         .rst(rst),
         .pc_in(pc_inst0_out),
         .instruction_in(branch_flush ? 32'h13 : module_instr_in),
+<<<<<<< HEAD
         .stall(stall_pipeline), // Stall on load-use hazard
+=======
+        .stall(stall_pipeline || stall), // Stall on load-use hazard or cache miss
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
         .pc_out(if_id_pc_out),
         .instruction_out(if_id_instr_out)
     );
@@ -151,7 +167,11 @@ module riscv_cpu (
         .pc_in(if_id_pc_out),
         .rs1_value_in(rf_inst0_rs1_value_out),
         .rs2_value_in(rf_inst0_rs2_value_out),
+<<<<<<< HEAD
         .stall(pipeline_flush || stall_pipeline), // Use combined flush
+=======
+        .stall(pipeline_flush || stall_pipeline || stall), // Use combined flush or stall on cache miss
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
         .rs1_valid_out(id_ex_inst0_rs1_valid_out),
         .rs2_valid_out(id_ex_inst0_rs2_valid_out),
         .rd_valid_out(id_ex_inst0_rd_valid_out),

--- a/rtl/top.v
+++ b/rtl/top.v
@@ -30,6 +30,11 @@ module top (
     wire [3:0] cpu_write_byte_enable;  // Write byte enables
     wire [2:0] cpu_load_type;          // Load type
     wire [31:0] instr_read_data;
+<<<<<<< HEAD
+=======
+
+    wire stall;
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     
     // Timer module wires
     wire [31:0] timer_read_data;
@@ -84,7 +89,12 @@ module top (
         .module_read_addr(cpu_mem_read_addr),
         .module_write_addr(cpu_mem_write_addr),
         .module_write_byte_enable(cpu_write_byte_enable),
+<<<<<<< HEAD
         .module_load_type(cpu_load_type)
+=======
+        .module_load_type(cpu_load_type),
+        .stall(stall)
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     );
 
     // Instantiate instruction memory
@@ -101,6 +111,7 @@ module top (
     );
 
     // Instantiate data memory  
+<<<<<<< HEAD
     data_mem #(
         .DATA_WIDTH(32),
         .ADDR_WIDTH(32),
@@ -114,6 +125,32 @@ module top (
         .addr(data_mem_addr - `DATA_MEM_BASE),
         .wr_data(cpu_mem_write_data),
         .rd_data_out(data_mem_read_data)
+=======
+    cache_fsm #(
+        .DATA_WIDTH(32),
+        .ADDRESS_WIDTH(32),
+        .SETS(256),
+        .TAG_WIDTH(18),
+        .SET_WIDTH(8),
+        .OFFSET_WIDTH(4),
+        .WAY(4),
+        .BYTE_OFFSET(2),
+        .WORDS_PER_BLOCK(16),
+        .BYTES_PER_WORD(4),
+        .CACHE_SIZE(1024),
+        .MEM_SIZE(1048576)  // 1MB in bytes
+    ) data_mem_inst (
+        .clk(clk),
+        .reset(rst),
+        .write_en(cpu_mem_write_en && data_mem_access),
+        .read_en(cpu_mem_read_en && data_mem_access),
+        .write_bytes_enable(cpu_write_byte_enable),
+        .load_type(cpu_load_type),
+        .mem_add(data_mem_addr - `DATA_MEM_BASE),
+        .data_in(cpu_mem_write_data),
+        .data_out(data_mem_read_data),
+        .stall(stall)
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     );
     
     // Instantiate timer module

--- a/rtl/top.v
+++ b/rtl/top.v
@@ -30,11 +30,8 @@ module top (
     wire [3:0] cpu_write_byte_enable;  // Write byte enables
     wire [2:0] cpu_load_type;          // Load type
     wire [31:0] instr_read_data;
-<<<<<<< HEAD
-=======
 
     wire stall;
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     
     // Timer module wires
     wire [31:0] timer_read_data;
@@ -89,12 +86,8 @@ module top (
         .module_read_addr(cpu_mem_read_addr),
         .module_write_addr(cpu_mem_write_addr),
         .module_write_byte_enable(cpu_write_byte_enable),
-<<<<<<< HEAD
-        .module_load_type(cpu_load_type)
-=======
         .module_load_type(cpu_load_type),
         .stall(stall)
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     );
 
     // Instantiate instruction memory
@@ -111,21 +104,6 @@ module top (
     );
 
     // Instantiate data memory  
-<<<<<<< HEAD
-    data_mem #(
-        .DATA_WIDTH(32),
-        .ADDR_WIDTH(32),
-        .MEM_SIZE(1048576)  // 1MB in bytes
-    ) data_mem_inst (
-        .clk(clk),
-        .wr_en(cpu_mem_write_en && data_mem_access),
-        .rd_en(cpu_mem_read_en && data_mem_access),
-        .write_byte_enable(cpu_write_byte_enable),
-        .load_type(cpu_load_type),
-        .addr(data_mem_addr - `DATA_MEM_BASE),
-        .wr_data(cpu_mem_write_data),
-        .rd_data_out(data_mem_read_data)
-=======
     cache_fsm #(
         .DATA_WIDTH(32),
         .ADDRESS_WIDTH(32),
@@ -150,7 +128,6 @@ module top (
         .data_in(cpu_mem_write_data),
         .data_out(data_mem_read_data),
         .stall(stall)
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     );
     
     // Instantiate timer module

--- a/sim/c_runner.mk
+++ b/sim/c_runner.mk
@@ -16,10 +16,6 @@ INCLUDES = -I$(shell pwd)/../rtl/include/ -I$(shell pwd)/../rtl/
 EXTRA_ARGS = $(INCLUDES)
 # Simulator
 SIM = verilator
-<<<<<<< HEAD
-=======
-WAVES = 1
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
 
 #Check if INSTRUCTION_MEMORY_HEX is set, if not, raise an error
 ifndef INSTRUCTION_MEMORY_HEX

--- a/sim/c_runner.mk
+++ b/sim/c_runner.mk
@@ -16,6 +16,10 @@ INCLUDES = -I$(shell pwd)/../rtl/include/ -I$(shell pwd)/../rtl/
 EXTRA_ARGS = $(INCLUDES)
 # Simulator
 SIM = verilator
+<<<<<<< HEAD
+=======
+WAVES = 1
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
 
 #Check if INSTRUCTION_MEMORY_HEX is set, if not, raise an error
 ifndef INSTRUCTION_MEMORY_HEX

--- a/sim/test_uart_hello.c
+++ b/sim/test_uart_hello.c
@@ -1,7 +1,4 @@
-<<<<<<< HEAD
-// Memory mapped addresses
-=======
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
+//memory mapped address
 #define UART_BASE       0x20000000
 #define UART_DATA       (UART_BASE + 0x00)
 #define UART_STATUS     (UART_BASE + 0x04)

--- a/sim/test_uart_hello.c
+++ b/sim/test_uart_hello.c
@@ -1,4 +1,7 @@
+<<<<<<< HEAD
 // Memory mapped addresses
+=======
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
 #define UART_BASE       0x20000000
 #define UART_DATA       (UART_BASE + 0x00)
 #define UART_STATUS     (UART_BASE + 0x04)

--- a/tb/cache_tb_v.v
+++ b/tb/cache_tb_v.v
@@ -1,0 +1,183 @@
+module cache_fsm_tb;
+
+    // Parameters - matching the cache design
+    parameter MEM_SIZE        = 1048576;
+    parameter CACHE_SIZE      = 1024;
+    parameter SETS            = 256;
+    parameter ADDRESS_WIDTH   = 32;
+    parameter DATA_WIDTH      = 32;
+    parameter TAG_WIDTH       = 18;
+    parameter SET_WIDTH       = 8;
+    parameter OFFSET_WIDTH    = 4;
+    parameter WAY             = 4;
+    parameter BYTE_OFFSET     = 2;
+    parameter WORDS_PER_BLOCK = 16;
+    parameter BYTES_PER_WORD  = 4;
+    
+    parameter CLK_PERIOD = 10;
+
+    // Testbench signals
+    logic                              clk;
+    logic                              write_en;
+    logic                              read_en;
+    logic                              reset;
+    logic [DATA_WIDTH - 1 : 0]         data_in;
+    logic [ADDRESS_WIDTH - 1 : 0]      mem_add;
+    logic                              stall;
+    logic [DATA_WIDTH - 1 : 0]         data_out;
+    logic [3 : 0]                      write_bytes_enable;
+    logic [2 : 0]                      load_type;
+
+
+    // Instantiate the cache FSM
+    cache_fsm #(
+        .MEM_SIZE(MEM_SIZE),
+        .CACHE_SIZE(CACHE_SIZE),
+        .SETS(SETS),
+        .ADDRESS_WIDTH(ADDRESS_WIDTH),
+        .DATA_WIDTH(DATA_WIDTH),
+        .TAG_WIDTH(TAG_WIDTH),
+        .SET_WIDTH(SET_WIDTH),
+        .OFFSET_WIDTH(OFFSET_WIDTH),
+        .WAY(WAY),
+        .BYTE_OFFSET(BYTE_OFFSET),
+        .WORDS_PER_BLOCK(WORDS_PER_BLOCK),
+        .BYTES_PER_WORD(BYTES_PER_WORD)
+    ) dut (
+        .clk(clk),
+        .write_en(write_en),
+        .read_en(read_en),
+        .reset(reset),
+        .data_in(data_in),
+        .mem_add(mem_add),
+        .stall(stall),
+        .data_out(data_out),
+        .write_bytes_enable(write_bytes_enable),
+        .load_type(load_type)
+    );
+
+    // Clock generation
+    initial begin
+        clk = 0;
+        forever #(CLK_PERIOD/2) clk = ~clk;
+    end
+
+    initial begin
+        reset = 1;
+        repeat(2)@(posedge clk);
+        reset = 0;
+
+        for(integer  i = 0; i < MEM_SIZE; i++) begin
+            for (integer j = 0; j < WORDS_PER_BLOCK; j++) begin
+                for(integer k = 0; k < BYTES_PER_WORD; k++) begin
+                    dut.MAIN_MEMORY[i][j][k] = 0;
+                end 
+            end
+        end
+
+//test 1- write some data and recheck if written properly 
+        write_bytes_enable = 4'b1111;
+        mem_add = 32'h0000_00F0;
+        data_in = 32'hFBFC_FDFE;
+        @(posedge clk);
+        write_en = 1;
+        @(posedge clk);
+        write_en = 0;
+        repeat(8)@(posedge clk);
+//see if the block was correctly loaded from the main memory and read the word
+        load_type = 010;
+        read_en = 1;
+        repeat(3)@(posedge clk);
+        read_en = 0;
+
+//test 2- check unsigned byte read after writing at the same tag(for me to check byte offset correctness)
+        write_bytes_enable = 4'b0001;
+        mem_add = 32'b0000_0000_0000_0000_0000_0000_1111_0011;
+        data_in = 32'hFFFF_FFFF;
+        @(posedge clk);
+        write_en = 1;
+        @(posedge clk);
+        write_en = 0;
+        repeat(8)@(posedge clk);
+
+        load_type = 100;
+        read_en = 1;
+        repeat(2)@(posedge clk);
+        read_en = 0;
+
+//test 3- check sign extend byte access
+        load_type = 000;
+        read_en   = 1;
+        repeat(2)@(posedge clk);
+        read_en = 0;
+
+
+
+//test 4- fill all ways and test writebacks and read from main memory
+
+        write_bytes_enable = 4'b1111;
+        mem_add = 32'h0F00_00F0;
+        data_in = 32'hABAB_FDFE;
+        @(posedge clk);
+        write_en = 1;
+        @(posedge clk);
+        write_en = 0;
+        repeat(8)@(posedge clk);
+//see if the block was correctly loaded from the main memory and read the word
+        load_type = 010;
+        read_en = 1;
+        repeat(3)@(posedge clk);
+        read_en = 0;
+
+        write_bytes_enable = 4'b1111;
+        mem_add = 32'h0D00_00F0;
+        data_in = 32'hFBFC_ABAB;
+        @(posedge clk);
+        write_en = 1;
+        @(posedge clk);
+        write_en = 0;
+        repeat(8)@(posedge clk);
+//see if the block was correctly loaded from the main memory and read the word
+        load_type = 010;
+        read_en = 1;
+        repeat(3)@(posedge clk);
+        read_en = 0;
+
+        write_bytes_enable = 4'b0011;
+        mem_add = 32'h0B00_00F0;
+        data_in = 32'hFBAB_ABFE;
+        @(posedge clk);
+        write_en = 1;
+        @(posedge clk);
+        write_en = 0;
+        repeat(8)@(posedge clk);
+//see if the block was correctly loaded from the main memory and read the word
+        load_type = 010;
+        read_en = 1;
+        repeat(3)@(posedge clk);
+        read_en = 0;  
+
+//test 5- writeback the lru to the main memory and reread it to check reads from the main memory
+//write something new to cause eviction 
+        write_bytes_enable = 4'b1111;
+        mem_add = 32'h0900_00F0;
+        data_in = 32'hDEAD_BEAD;
+        @(posedge clk);
+        write_en = 1;
+        @(posedge clk);
+        write_en = 0;
+        repeat(8)@(posedge clk);
+//see if the block was correctly loaded from the main memory and read the word
+        load_type = 010;
+        read_en = 1;
+        repeat(3)@(posedge clk);
+        read_en = 0;   
+
+        mem_add = 32'h0D00_00F0;
+        load_type = 010;
+        read_en = 1;
+        repeat(10)@(posedge clk);  //expect FBFC_ABAB          
+
+        $finish;
+    end
+endmodule

--- a/tests/system_tests/test_cache.py
+++ b/tests/system_tests/test_cache.py
@@ -1,0 +1,280 @@
+"""
+same as the cache_tb_v.v in the tb/ folder only with cocotb format
+
+Run:
+    pytest system_tests/test_cache.py -s -v
+    WAVES=1 pytest system_tests/test_cache.py -s -v
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+from cocotb.clock import Clock
+from cocotb_test.simulator import run
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Parameters — must match runCocotbTests()
+# ---------------------------------------------------------------------------
+MEM_SIZE        = 1048576
+CACHE_SIZE      = 1024
+SETS            = 256
+ADDRESS_WIDTH   = 32
+DATA_WIDTH      = 32
+TAG_WIDTH       = 18
+SET_WIDTH       = 8
+OFFSET_WIDTH    = 4
+WAY             = 4
+BYTE_OFFSET     = 2
+WORDS_PER_BLOCK = 16
+BYTES_PER_WORD  = 4
+CLK_PERIOD      = 10   
+
+
+@cocotb.test()
+async def test_cache_fsm(dut):
+    """
+    Full port of cache_fsm_tb.sv.
+    Tests: full-word write/read, byte-enable, sign-extension,
+           way filling, LRU eviction, writeback, re-read from main memory.
+    """
+
+    # Start clock
+    clock = Clock(dut.clk, CLK_PERIOD, units="ns")
+    cocotb.start_soon(clock.start())
+
+    # -------------------------------------------------------------------
+    # Reset — mirrors: reset=1; repeat(2)@posedge; reset=0
+    # -------------------------------------------------------------------
+    dut.reset.value              = 1
+    dut.write_en.value           = 0
+    dut.read_en.value            = 0
+    dut.data_in.value            = 0
+    dut.mem_add.value            = 0
+    dut.write_bytes_enable.value = 0
+    dut.load_type.value          = 0
+    await ClockCycles(dut.clk, 2)
+    dut.reset.value = 0
+
+    # ===================================================================
+    # TEST 1 – full-word write + read back
+    # ===================================================================
+    print("\n##########################################")
+    print("  TEST 1: full-word write + read back")
+    print("  addr=0x0000_00F0  data=0xFBFC_FDFE  be=1111")
+    print("##########################################")
+
+    dut.write_bytes_enable.value = 0b1111
+    dut.mem_add.value            = 0x000000F0
+    dut.data_in.value            = 0xFBFCFDFE
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 1
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 0
+    await ClockCycles(dut.clk, 8)
+
+    dut.load_type.value = 0b010   # LW
+    dut.read_en.value   = 1
+    await ClockCycles(dut.clk, 3)
+    dut.read_en.value = 0
+
+
+    # ===================================================================
+    # TEST 2 – byte-enable write (be=0001) + unsigned byte read (LBU)
+    # ===================================================================
+    print("\n##########################################")
+    print("  TEST 2: byte write (be=0001) + unsigned byte read")
+    print("  addr=0x0000_00F3  data[7:0]=0xFF  load_type=100 (LBU)")
+    print("##########################################")
+
+    dut.write_bytes_enable.value = 0b0001
+    dut.mem_add.value            = 0b00000000000000000000000011110011
+    dut.data_in.value            = 0x000000FF
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 1
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 0
+    await ClockCycles(dut.clk, 8)
+
+    dut.load_type.value = 0b100   # LBU
+    dut.read_en.value   = 1
+    await ClockCycles(dut.clk, 2)
+    dut.read_en.value = 0
+
+    # ===================================================================
+    # TEST 3 – signed byte read (same address, load_type=000 LB)
+    # ===================================================================
+    print("\n##########################################")
+    print("  TEST 3: signed byte read (same addr)")
+    print("  load_type=000 (LB)  expect sign-extended 0xFF -> 0xFFFFFFFF")
+    print("##########################################")
+
+    dut.load_type.value = 0b000   # LB
+    dut.read_en.value   = 1
+    await ClockCycles(dut.clk, 3)
+    dut.read_en.value = 0
+
+    try:
+        data_out = int(dut.data_out.value)
+    except Exception:
+        data_out = 0
+    print(f"  data_out after LB = 0x{data_out:08x}  (expect 0xFFFFFFFF)")
+
+    # ===================================================================
+    # TEST 4 – fill all 4 ways
+    # ===================================================================
+    print("\n##########################################")
+    print("  TEST 4: fill all ways (3 more writes to same set)")
+    print("##########################################")
+
+    # --- 4a ---
+    dut.write_bytes_enable.value = 0b1111
+    dut.mem_add.value            = 0x0F0000F0
+    dut.data_in.value            = 0xABABFDFE
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 1
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 0
+    await ClockCycles(dut.clk, 8)
+
+    dut.load_type.value = 0b010
+    dut.read_en.value   = 1
+    await ClockCycles(dut.clk, 3)
+    dut.read_en.value = 0
+
+    print("  [4a] after write 0x0F00_00F0:")
+
+    # --- 4b ---
+    dut.write_bytes_enable.value = 0b1111
+    dut.mem_add.value            = 0x0D0000F0
+    dut.data_in.value            = 0xFBFCABAB
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 1
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 0
+    await ClockCycles(dut.clk, 8)
+
+    dut.load_type.value = 0b010
+    dut.read_en.value   = 1
+    await ClockCycles(dut.clk, 3)
+    dut.read_en.value = 0
+
+    print("  [4b] after write 0x0D00_00F0:")
+
+    # --- 4c (halfword enable be=0011) ---
+    dut.write_bytes_enable.value = 0b0011
+    dut.mem_add.value            = 0x0B0000F0
+    dut.data_in.value            = 0xFBABABFE
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 1
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 0
+    await ClockCycles(dut.clk, 8)
+
+    dut.load_type.value = 0b010
+    dut.read_en.value   = 1
+    await ClockCycles(dut.clk, 3)
+    dut.read_en.value = 0
+
+    print("  [4c] after write 0x0B00_00F0 (all 4 ways now full):")
+
+    # ===================================================================
+    # TEST 5 – force LRU eviction + writeback + re-read from main memory
+    # ===================================================================
+    print("\n##########################################")
+    print("  TEST 5: eviction + writeback + re-read from main memory")
+    print("  new write  addr=0x0900_00F0  data=0xDEAD_BEAD")
+    print("  expect LRU victim written back to main memory")
+    print("  then re-read 0x0D00_00F0 -> expect 0xFBFC_ABAB")
+    print("##########################################")
+
+    dut.write_bytes_enable.value = 0b1111
+    dut.mem_add.value            = 0x090000F0
+    dut.data_in.value            = 0xDEADBEAD
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 1
+    await RisingEdge(dut.clk)
+    dut.write_en.value = 0
+    await ClockCycles(dut.clk, 8)
+
+    dut.load_type.value = 0b010
+    dut.read_en.value   = 1
+    await ClockCycles(dut.clk, 3)
+    dut.read_en.value = 0
+
+
+    # Re-read evicted address — mirrors: mem_add=0x0D00_00F0; read_en=1; repeat(10)
+    dut.mem_add.value   = 0x0D0000F0
+    dut.load_type.value = 0b010
+    dut.read_en.value   = 1
+    await ClockCycles(dut.clk, 10)
+
+    try:
+        data_out = int(dut.data_out.value)
+    except Exception:
+        data_out = 0
+    print(f"  [5b] re-read 0x0D00_00F0 (from main mem after eviction):")
+    print(f"       data_out = 0x{data_out:08x}  (expect 0xFBFC_ABAB)")
+
+    assert data_out == 0xFBFCABAB, \
+        f"TEST5 re-read: expected 0xFBFCABAB, got 0x{data_out:08x}"
+
+    print("\nAll tests completed successfully.")
+
+
+# ---------------------------------------------------------------------------
+# pytest entry point
+# ---------------------------------------------------------------------------
+def runCocotbTests():
+    root_dir = os.getcwd()
+    while not os.path.exists(os.path.join(root_dir, "rtl")):
+        parent = os.path.dirname(root_dir)
+        if parent == root_dir:
+            raise FileNotFoundError("rtl directory not found")
+        root_dir = parent
+
+    rtl_dir  = Path(root_dir) / "rtl"
+    incl_dir = rtl_dir / "include"
+    sources  = [str(rtl_dir / "cache_fsm.v")]
+
+    enable_waves = os.getenv("WAVES", "0") == "1"
+    wave_dir = Path(os.getcwd()) / "waveforms"
+    plus_args = []
+    if enable_waves:
+        wave_dir.mkdir(exist_ok=True)
+        plus_args = [f"+dumpfile={wave_dir / 'cache_fsm_test.vcd'}"]
+
+    print("\n" + "="*60)
+    print("  Running: test_cache_fsm")
+    print("="*60)
+
+    run(
+        verilog_sources=sources,
+        toplevel="cache_fsm",
+        module="test_cache",
+        testcase="test_cache_fsm",
+        includes=[str(incl_dir)],
+        simulator="verilator",
+        timescale="1ns/1ps",
+        plus_args=plus_args,
+        extra_env={"COCOTB_LOG_LEVEL": "INFO"},
+        compile_args=["-Wno-WIDTHTRUNC", "-Wno-WIDTHEXPAND", "-Wno-fatal"],
+        parameters={
+            "MEM_SIZE":        MEM_SIZE,
+            "CACHE_SIZE":      CACHE_SIZE,
+            "SETS":            SETS,
+            "ADDRESS_WIDTH":   ADDRESS_WIDTH,
+            "DATA_WIDTH":      DATA_WIDTH,
+            "TAG_WIDTH":       TAG_WIDTH,
+            "SET_WIDTH":       SET_WIDTH,
+            "OFFSET_WIDTH":    OFFSET_WIDTH,
+            "WAY":             WAY,
+            "BYTE_OFFSET":     BYTE_OFFSET,
+            "WORDS_PER_BLOCK": WORDS_PER_BLOCK,
+            "BYTES_PER_WORD":  BYTES_PER_WORD,
+        },
+    )
+
+
+if __name__ == "__main__":
+    runCocotbTests()

--- a/tests/system_tests/test_fibonacci.py
+++ b/tests/system_tests/test_fibonacci.py
@@ -263,11 +263,7 @@ def runCocotbTests():
         simulator="verilator",
         timescale="1ns/1ps",
         plus_args=plus_args,
-<<<<<<< HEAD
-        defines=[f"INSTR_HEX_FILE=\"{hex_file}\""]  # Pass as Verilog define
-=======
         defines=[f"INSTR_HEX_FILE=\"{hex_file}\""]# Pass as Verilog define
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     )
 
 if __name__ == "__main__":

--- a/tests/system_tests/test_fibonacci.py
+++ b/tests/system_tests/test_fibonacci.py
@@ -263,7 +263,11 @@ def runCocotbTests():
         simulator="verilator",
         timescale="1ns/1ps",
         plus_args=plus_args,
+<<<<<<< HEAD
         defines=[f"INSTR_HEX_FILE=\"{hex_file}\""]  # Pass as Verilog define
+=======
+        defines=[f"INSTR_HEX_FILE=\"{hex_file}\""]# Pass as Verilog define
+>>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     )
 
 if __name__ == "__main__":

--- a/tests/system_tests/test_fibonacci.py
+++ b/tests/system_tests/test_fibonacci.py
@@ -263,12 +263,9 @@ def runCocotbTests():
         simulator="verilator",
         timescale="1ns/1ps",
         plus_args=plus_args,
-<<<<<<< HEAD
         defines=[f"INSTR_HEX_FILE=\"{hex_file}\""]  # Pass as Verilog define
-=======
-        defines=[f"INSTR_HEX_FILE=\"{hex_file}\""]# Pass as Verilog define
->>>>>>> 2adc67a (added the dcache, its testbenches, integrated with the cpu and tested it with the present tests and data memory is of no use now but still present)
     )
+
 
 if __name__ == "__main__":
     runCocotbTests()


### PR DESCRIPTION
added the dcache support, integrated it with the top module.
Replaced the data memory completely, the new one is also byte addressable(obviously) but can fetch whole blocks for me now.
still keep the data_mem module i might need it for debugging purposes later (hopefully not)
Stalled (ORed with the pipeline stall) IF_ID and ID_EX stages whenever a cache miss occurs(see comments)
Added a verilog testbench in the tb/ folder and the cocotb testbench in the tests/system_tests/ folder. 