### PR TITLE
ci: fix prebuilt image Dockerfile path

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .devcontainer
-          file: Dockerfile
+          file: .devcontainer/Dockerfile
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:linux


### PR DESCRIPTION
Fixes the development-container image workflow after #26.

The workflow uses `.devcontainer` as the Docker build context, but `docker/build-push-action` resolves the `file` input from the repository workspace. `file: Dockerfile` therefore fails with `failed to read dockerfile: open Dockerfile: no such file or directory`.

This changes it to `file: .devcontainer/Dockerfile` while retaining the smaller `.devcontainer` build context.
