### PR TITLE
ci: add dedicated ISA image and reuse Verilator build

### DIFF
--- a/.github/isa/Dockerfile
+++ b/.github/isa/Dockerfile
@@ -1,0 +1,82 @@
+FROM ubuntu:24.04
+
+ARG SPIKE_VERSION=v1.1.0
+ARG RISCV_TESTS_VERSION=2ebecad997fa58cd9e5724340ba75aa4b59bd1d0
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    RISCV=/usr \
+    RISCV_TESTS_DIR=/opt/riscv-tests \
+    VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:/opt/spike/bin:$PATH
+
+LABEL org.opencontainers.image.title="synapse32 ISA golden test environment" \
+      org.opencontainers.image.description="Pinned Spike and prebuilt riscv-tests corpus for Synapse32" \
+      org.opencontainers.image.source="https://github.com/5iri/synapse32"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        autotools-dev \
+        binutils-riscv64-unknown-elf \
+        bison \
+        build-essential \
+        ca-certificates \
+        device-tree-compiler \
+        flex \
+        gawk \
+        gcc-riscv64-unknown-elf \
+        git \
+        gperf \
+        libboost-filesystem-dev \
+        libboost-regex-dev \
+        libboost-system-dev \
+        libexpat1-dev \
+        libgmp-dev \
+        libmpc-dev \
+        libmpfr-dev \
+        libtool \
+        make \
+        ninja-build \
+        patchutils \
+        picolibc-riscv64-unknown-elf \
+        python3 \
+        python3-venv \
+        texinfo \
+        verilator \
+        zlib1g-dev && \
+    verilator --version | grep -Eq '^Verilator 5\.' && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --branch "$SPIKE_VERSION" \
+        https://github.com/riscv-software-src/riscv-isa-sim.git /tmp/riscv-isa-sim && \
+    mkdir /tmp/riscv-isa-sim/build && \
+    cd /tmp/riscv-isa-sim/build && \
+    ../configure CXXFLAGS="-include cstdint" --prefix=/opt/spike && \
+    make -j"$(nproc)" && \
+    make install && \
+    rm -rf /tmp/riscv-isa-sim
+
+RUN git clone --depth 1 --recurse-submodules \
+        https://github.com/riscv-software-src/riscv-tests.git "$RISCV_TESTS_DIR" && \
+    cd "$RISCV_TESTS_DIR" && \
+    git checkout "$RISCV_TESTS_VERSION" && \
+    autoconf && \
+    ./configure --prefix="$RISCV_TESTS_DIR/install" && \
+    cd isa && \
+    for suite in rv32ui rv32um rv32ua rv32mi rv32si; do \
+        for source in "$suite"/*.S; do \
+            make -j"$(nproc)" XLEN=32 "$(dirname "$source")-p-$(basename "$source" .S)"; \
+        done; \
+    done && \
+    find "$RISCV_TESTS_DIR/isa" -maxdepth 1 -type f \
+        \( -name 'rv32ui-p-*' -o -name 'rv32um-p-*' -o -name 'rv32ua-p-*' \
+           -o -name 'rv32mi-p-*' -o -name 'rv32si-p-*' \) -print | sort
+
+COPY tests/requirements.txt /tmp/isa-requirements.txt
+RUN python3 -m venv "$VIRTUAL_ENV" && \
+    "$VIRTUAL_ENV/bin/pip" install --no-cache-dir --upgrade pip && \
+    "$VIRTUAL_ENV/bin/pip" install --no-cache-dir -r /tmp/isa-requirements.txt && \
+    rm /tmp/isa-requirements.txt
+
+WORKDIR /workspace
+CMD ["/bin/bash"]

--- a/.github/scripts/compare_with_spike.py
+++ b/.github/scripts/compare_with_spike.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Compare riscv-tests results between Spike (golden) and Verilator model.
+
+Assumes riscv-tests has already been built, producing ELF binaries under:
+  <riscv-tests>/isa/rv32*-p-*
+
+Usage:
+  python .github/scripts/compare_with_spike.py --riscv-tests /path/to/riscv-tests
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+DEFAULT_SUITES = "rv32ui,rv32um,rv32ua,rv32mi,rv32si"
+TEST_NAME_RE = re.compile(r"^(rv32(ui|um|ua|mi|si))-p-[A-Za-z0-9_-]+$")
+SPIKE_ISA = "rv32ima_zicsr_zicntr"
+
+
+def parse_suites(suites: str) -> set[str]:
+    return {suite.strip() for suite in suites.split(",") if suite.strip()}
+
+
+def run(cmd: list[str], env: dict[str, str] | None = None, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, env=env, cwd=cwd, text=True, capture_output=True)
+
+
+def find_repo_root() -> Path:
+    cur = Path.cwd()
+    while not (cur / "rtl").exists():
+        if cur.parent == cur:
+            raise FileNotFoundError("Could not locate repo root (no rtl/ directory found)")
+        cur = cur.parent
+    return cur
+
+
+def discover_tests(isa_dir: Path, suites: set[str], limit: int) -> list[Path]:
+    tests = []
+    for p in sorted(isa_dir.iterdir()):
+        if not p.is_file():
+            continue
+        match = TEST_NAME_RE.match(p.name)
+        if match and match.group(1) in suites:
+            tests.append(p)
+    if limit > 0:
+        tests = tests[:limit]
+    return tests
+
+
+def require_suites(tests: list[Path], required: set[str]) -> None:
+    discovered = {
+        match.group(1)
+        for test in tests
+        if (match := TEST_NAME_RE.match(test.name))
+    }
+    missing = sorted(required - discovered)
+    if missing:
+        found = ", ".join(sorted(discovered)) or "<none>"
+        raise RuntimeError(
+            "Missing required riscv-tests suites: "
+            f"{', '.join(missing)}. Discovered suites: {found}"
+        )
+
+
+def tohost_addr(elf: Path) -> int:
+    nm = run(["riscv64-unknown-elf-nm", str(elf)])
+    if nm.returncode != 0:
+        raise RuntimeError(f"nm failed for {elf}:\n{nm.stderr}")
+    for line in nm.stdout.splitlines():
+        parts = line.strip().split()
+        if len(parts) >= 3 and parts[-1] == "tohost":
+            return int(parts[0], 16)
+    raise RuntimeError(f"tohost symbol not found in {elf}")
+
+
+def elf_to_hex(elf: Path, out_hex: Path) -> None:
+    out_hex.parent.mkdir(parents=True, exist_ok=True)
+    bin_file = out_hex.with_suffix(".bin")
+    rc = run(["riscv64-unknown-elf-objcopy", "-O", "binary", str(elf), str(bin_file)])
+    if rc.returncode != 0:
+        raise RuntimeError(f"objcopy binary failed for {elf}:\n{rc.stderr}")
+    rc = run(
+        [
+            "riscv64-unknown-elf-objcopy",
+            "-I",
+            "binary",
+            "-O",
+            "verilog",
+            "--verilog-data-width=4",
+            "--reverse-bytes=4",
+            str(bin_file),
+            str(out_hex),
+        ]
+    )
+    if rc.returncode != 0:
+        raise RuntimeError(f"objcopy verilog failed for {elf}:\n{rc.stderr}")
+
+
+def run_spike(elf: Path) -> tuple[bool, str]:
+    rc = run(["spike", "--isa=" + SPIKE_ISA, str(elf)])
+    ok = rc.returncode == 0
+    detail = (rc.stdout + "\n" + rc.stderr).strip()
+    return ok, detail
+
+
+def run_verilator(
+    repo_root: Path,
+    hex_file: Path,
+    runtime_hex: Path,
+    sim_build: Path,
+    tohost: int,
+    max_cycles: int,
+    compile_model: bool,
+) -> tuple[bool, str]:
+    # The image is read by the RTL at simulator start.  Keep the Verilog
+    # define and build directory constant, changing only the file contents.
+    runtime_hex.parent.mkdir(parents=True, exist_ok=True)
+    runtime_hex.write_bytes(hex_file.read_bytes())
+    env = os.environ.copy()
+    env["ISA_HEX_FILE"] = str(runtime_hex)
+    env["ISA_SIM_HEX_FILE"] = str(runtime_hex)
+    env["ISA_SIM_BUILD"] = str(sim_build)
+    env["ISA_FORCE_COMPILE"] = "1" if compile_model else "0"
+    env["ISA_TOHOST_ADDR"] = hex(tohost)
+    env["ISA_MAX_CYCLES"] = str(max_cycles)
+    rc = run([sys.executable, "tests/system_tests/test_riscv_isa.py"], env=env, cwd=repo_root)
+    ok = rc.returncode == 0
+    detail = (rc.stdout + "\n" + rc.stderr).strip()
+    return ok, detail
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--riscv-tests", required=True, type=Path, help="Path to built riscv-tests repo")
+    ap.add_argument("--limit", type=int, default=0, help="Limit number of ISA tests (0 = all)")
+    ap.add_argument("--max-cycles", type=int, default=200000, help="Max cycles per Verilator ISA test")
+    ap.add_argument("--report", type=Path, default=Path(".github/artifacts/isa/compare_report.json"))
+    ap.add_argument(
+        "--suites",
+        default=DEFAULT_SUITES,
+        help="Comma-separated riscv-tests suite prefixes to compare",
+    )
+    args = ap.parse_args()
+
+    repo_root = find_repo_root()
+    isa_dir = args.riscv_tests / "isa"
+    if not isa_dir.exists():
+        print(f"Missing isa dir: {isa_dir}", file=sys.stderr)
+        return 2
+
+    suites = parse_suites(args.suites)
+    all_tests = discover_tests(isa_dir, suites, 0)
+    require_suites(all_tests, suites)
+    tests = all_tests[: args.limit] if args.limit > 0 else all_tests
+    if not tests:
+        print("No rv32*-p-* test binaries found. Did riscv-tests build succeed?", file=sys.stderr)
+        return 2
+
+    out_hex_dir = repo_root / ".github" / "artifacts" / "isa" / "build_hex"
+    runtime_hex = repo_root / ".github" / "artifacts" / "isa" / "runtime.hex"
+    sim_build = repo_root / ".github" / "artifacts" / "isa" / "sim_build_riscv_isa"
+    results = []
+    mismatches = []
+
+    for index, elf in enumerate(tests):
+        try:
+            th = tohost_addr(elf)
+            hex_file = out_hex_dir / f"{elf.name}.hex"
+            elf_to_hex(elf, hex_file)
+            spike_ok, spike_log = run_spike(elf)
+            verilator_ok, verilator_log = run_verilator(
+                repo_root,
+                hex_file,
+                runtime_hex,
+                sim_build,
+                th,
+                args.max_cycles,
+                compile_model=index == 0,
+            )
+            same = spike_ok == verilator_ok
+            rec = {
+                "test": elf.name,
+                "spike_pass": spike_ok,
+                "verilator_pass": verilator_ok,
+                "match": same,
+                "tohost": f"0x{th:x}",
+            }
+            results.append(rec)
+            if not same:
+                mismatches.append(
+                    {
+                        **rec,
+                        "spike_log_tail": spike_log[-8000:],
+                        "verilator_log_tail": verilator_log[-8000:],
+                    }
+                )
+            print(f"[{elf.name}] spike={spike_ok} verilator={verilator_ok} match={same}")
+        except Exception as exc:
+            rec = {
+                "test": elf.name,
+                "spike_pass": False,
+                "verilator_pass": False,
+                "match": False,
+                "error": str(exc),
+            }
+            results.append(rec)
+            mismatches.append(rec)
+            print(f"[{elf.name}] ERROR: {exc}")
+
+    summary = {
+        "total": len(results),
+        "matches": len([r for r in results if r.get("match")]),
+        "mismatches": len(mismatches),
+        "results": results,
+        "mismatch_details": mismatches,
+    }
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(summary, indent=2), encoding="ascii")
+    print(f"Wrote report: {args.report}")
+
+    return 0 if not mismatches else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/isa-golden-image.yml
+++ b/.github/workflows/isa-golden-image.yml
@@ -1,0 +1,97 @@
+name: ISA Golden Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/isa/**"
+      - ".github/workflows/isa-golden-image.yml"
+      - "tests/requirements.txt"
+      - "rtl/**"
+      - "tests/**"
+      - ".github/scripts/**"
+  pull_request:
+    paths:
+      - ".github/isa/**"
+      - ".github/workflows/isa-golden-image.yml"
+      - "tests/requirements.txt"
+      - "rtl/**"
+      - "tests/**"
+      - ".github/scripts/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/synapse32-isa
+
+jobs:
+  build-test-publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set image tags
+        id: tags
+        run: |
+          image_name="ghcr.io/${GITHUB_REPOSITORY,,}-isa"
+          echo "immutable=${image_name}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "linux=${image_name}:linux" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build ISA image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/isa/Dockerfile
+          tags: |
+            ${{ steps.tags.outputs.immutable }}
+            ${{ steps.tags.outputs.linux }}
+          load: true
+          push: false
+          cache-from: type=gha,scope=isa-image
+          cache-to: type=gha,mode=max,scope=isa-image
+
+      - name: Run ISA golden comparison
+        env:
+          ISA_IMAGE: ${{ steps.tags.outputs.immutable }}
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$ISA_IMAGE" \
+            /opt/venv/bin/python .github/scripts/compare_with_spike.py \
+              --riscv-tests /opt/riscv-tests \
+              --suites rv32ui,rv32um,rv32ua,rv32mi,rv32si \
+              --report .github/artifacts/isa/compare_report.json
+
+      - name: Publish tested image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          IMMUTABLE_IMAGE: ${{ steps.tags.outputs.immutable }}
+          LINUX_IMAGE: ${{ steps.tags.outputs.linux }}
+        run: |
+          docker push "$IMMUTABLE_IMAGE"
+          docker push "$LINUX_IMAGE"
+
+      - name: Upload compare report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: isa-golden-report
+          path: .github/artifacts/isa/compare_report.json
+          if-no-files-found: error

--- a/tests/system_tests/test_riscv_isa.py
+++ b/tests/system_tests/test_riscv_isa.py
@@ -1,0 +1,128 @@
+"""Run a prebuilt ISA test image on the core and determine pass/fail via tohost.
+
+Environment variables:
+  ISA_HEX_FILE      : absolute path to verilog-hex image
+  ISA_TOHOST_ADDR   : tohost symbol address (hex, e.g. 0x80001000)
+  ISA_MAX_CYCLES    : optional max cycles (default: 200000)
+"""
+import os
+import shutil
+from pathlib import Path
+
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles, RisingEdge
+from cocotb_test.simulator import run
+
+
+def _find_repo_root() -> Path:
+    cur = Path.cwd()
+    while not (cur / "rtl").exists():
+        if cur.parent == cur:
+            raise FileNotFoundError("Could not locate repo root (no rtl/ directory found)")
+        cur = cur.parent
+    return cur
+
+
+@cocotb.test()
+async def test_riscv_isa_image(dut):
+    tohost_addr = int(os.environ["ISA_TOHOST_ADDR"], 16)
+    max_cycles = int(os.environ.get("ISA_MAX_CYCLES", "200000"))
+    trace_isa = os.environ.get("TRACE_ISA", "0") == "1"
+
+    clk = Clock(dut.clk, 10, units="ns")
+    cocotb.start_soon(clk.start())
+
+    dut.software_interrupt.value = 0
+    dut.external_interrupt.value = 0
+    dut.rst.value = 1
+    await ClockCycles(dut.clk, 5)
+    dut.rst.value = 0
+
+    for cycle in range(max_cycles):
+        await RisingEdge(dut.clk)
+        if trace_isa:
+            cocotb.log.info(
+                "cycle=%d pc=%#x priv=%#x mepc=%#x mcause=%#x mtval=%#x satp=%#x "
+                "rd=%d wr=%d raw_wr=%d mem_wr=%d raddr=%#x waddr=%#x wdata=%#x rdata=%#x "
+                "wb_en=%d wb_rd=%d wb_val=%#x lp=%d sp=%d pfaddr=%#x",
+                cycle,
+                int(dut.cpu_pc_out.value),
+                int(dut.cpu_inst.csr_file_inst.privilege_mode.value),
+                int(dut.cpu_inst.csr_file_inst.mepc.value),
+                int(dut.cpu_inst.csr_file_inst.mcause.value),
+                int(dut.cpu_inst.csr_file_inst.mtval.value),
+                int(dut.cpu_inst.csr_file_inst.satp.value),
+                int(dut.cpu_mem_read_en.value),
+                int(dut.cpu_mem_write_en.value),
+                int(dut.unified_mem_inst.data_wr_req.value),
+                int(dut.unified_mem_inst.wr_en.value),
+                int(dut.cpu_mem_read_addr.value),
+                int(dut.cpu_mem_write_addr.value),
+                int(dut.cpu_mem_write_data.value),
+                int(dut.mem_read_data.value),
+                int(dut.cpu_inst.rf_inst0_wr_en.value),
+                int(dut.cpu_inst.rf_inst0_rd_in.value),
+                int(dut.cpu_inst.rf_inst0_rd_value_in.value),
+                int(dut.cpu_load_page_fault.value),
+                int(dut.cpu_store_page_fault.value),
+                int(dut.cpu_page_fault_addr.value),
+            )
+        if int(dut.cpu_mem_write_en.value):
+            addr = int(dut.cpu_mem_write_addr.value)
+            data = int(dut.cpu_mem_write_data.value) & 0xFFFFFFFF
+            if addr == tohost_addr and (data & 1):
+                # riscv-tests convention: 1 = pass, else fail code in upper bits.
+                assert data == 1, f"ISA test reported failure via tohost: 0x{data:08x}"
+                return
+
+    assert False, f"ISA test did not finish within {max_cycles} cycles"
+
+
+def runCocotbTests():
+    required_env = ("ISA_HEX_FILE", "ISA_TOHOST_ADDR")
+    missing = [name for name in required_env if name not in os.environ]
+    if missing:
+        pytest.skip(f"Skipping ISA harness in full pytest run (missing env: {', '.join(missing)})")
+
+    repo_root = _find_repo_root()
+    rtl_dir = repo_root / "rtl"
+    incl_dir = rtl_dir / "include"
+    # Keep the image path stable across test invocations.  The comparison
+    # driver replaces this file between tests, so the Verilator model does
+    # not need to be rebuilt for every ELF.
+    hex_file = os.environ.get("ISA_SIM_HEX_FILE") or os.environ["ISA_HEX_FILE"]
+
+    sources = []
+    for root, _, files in os.walk(rtl_dir):
+        for file in files:
+            if file.endswith((".v", ".sv")):
+                sources.append(os.path.join(root, file))
+
+    sim_build = Path(
+        os.environ.get(
+            "ISA_SIM_BUILD",
+            str(Path.cwd() / "sim_build" / "sim_build_riscv_isa"),
+        )
+    )
+    force_compile = os.environ.get("ISA_FORCE_COMPILE", "0") == "1"
+    if force_compile and sim_build.exists():
+        shutil.rmtree(sim_build)
+
+    run(
+        verilog_sources=sources,
+        toplevel="top",
+        module="test_riscv_isa",
+        testcase="test_riscv_isa_image",
+        includes=[str(incl_dir)],
+        simulator="verilator",
+        timescale="1ns/1ps",
+        defines=[f'INSTR_HEX_FILE="{hex_file}"'],
+        sim_build=str(sim_build),
+        force_compile=force_compile,
+    )
+
+
+if __name__ == "__main__":
+    runCocotbTests()


### PR DESCRIPTION
## Scope

This PR is limited to CI infrastructure for ISA golden validation. It does **not** include MMU, PLIC, interrupt, memory-map, or other functional RTL changes. Those should be reviewed and rolled back independently in separate PRs.

## Changes

- Add a dedicated Ubuntu ISA validation image containing Verilator, Spike, the pinned `riscv-tests` corpus, the RISC-V toolchain, and Python dependencies.
- Build the image and run the ISA golden comparison on pull requests.
- Publish immutable SHA and `linux` image tags only from `main`.
- Reuse one Verilator build while swapping the runtime hex image for each ELF.
- Update the ISA system test to use the image-provided toolchain and artifacts.

## Files in this PR

- `.github/isa/Dockerfile`
- `.github/scripts/compare_with_spike.py`
- `.github/workflows/isa-golden-image.yml`
- `tests/system_tests/test_riscv_isa.py`

## Validation

- ISA image build passed.
- Spike-versus-Verilator golden comparison passed.
- Existing test workflow passed.

This PR intentionally contains no functional RTL changes, so its CI behavior can be reviewed and reverted independently.